### PR TITLE
feat: when create a new user redirect to user list page

### DIFF
--- a/src/pages/user/create.tsx
+++ b/src/pages/user/create.tsx
@@ -47,16 +47,13 @@ const Create = () => {
     try {
       await createUser(data);
 
-      setTimeout(() => {
-        setLoading(false);
-      }, 2000);
-
       toast.success('Seu usuário foi criado com sucesso!');
-      Router.push('/user');
+      await Router.push('/user');
     } catch (error) {
       toast.error('Algum dos campos está inválido!');
+    } finally {
       setLoading(false);
-    }
+    }	
   };
 
   return (

--- a/src/pages/user/create.tsx
+++ b/src/pages/user/create.tsx
@@ -3,6 +3,7 @@ import * as yup from 'yup';
 
 import { yupResolver } from '@hookform/resolvers/yup';
 import { GetServerSideProps } from 'next';
+import Router from 'next/router';
 import { parseCookies } from 'nookies';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -50,7 +51,8 @@ const Create = () => {
         setLoading(false);
       }, 2000);
 
-      toast.success('Seu User foi criado com sucesso, veja na Aba Usuários!');
+      toast.success('Seu usuário foi criado com sucesso!');
+      Router.push('/user');
     } catch (error) {
       toast.error('Algum dos campos está inválido!');
       setLoading(false);


### PR DESCRIPTION
# **Issue**
Related to #26 

# What changes
- Redirect to users list when a new user is created
- Remove `setTimeout` to toggle `setLoading` to false to avoid a memory leak changing a `state` in a unmount page 

# Impact
- User creation

# Evidencies
[creation-user.webm](https://github.com/biantris/admin-analytics/assets/75763403/f77e9267-9f73-4485-8ad4-7ca804a88153)
